### PR TITLE
Prevent unintentional hot bar overwrites

### DIFF
--- a/src/main/java/cz/lukynka/bettersavedhotbars/mixin/CreativeModeInventoryScreen.java
+++ b/src/main/java/cz/lukynka/bettersavedhotbars/mixin/CreativeModeInventoryScreen.java
@@ -56,6 +56,12 @@ public abstract class CreativeModeInventoryScreen {
             }
             return;
         }
+
+        if (slot == null || !slot.getItem().isEmpty()) {
+            player.inventoryMenu.setCarried(ItemStack.EMPTY);
+            return;
+        }
+        
         slot.set(item);
         var hotbar = hotbarManager.get(newHotbarInfo.row());
         hotbar.storeFrom(fakeInventoryWithModifiedHotbar(hotbar.load(registryAccess), newHotbarInfo.slot(), item), registryAccess);


### PR DESCRIPTION
When erasing items in inventory in creative mode, you can usually do so by placing the item in creative inventory. However, with this mod, placing an item on the hot bar tab will overwrite the item if it is already registered in the slot where you placed it, and you may inadvertently lose a important item that you have saved.

With this change, clicking on a slot in a hot bar tab that already has an item in it will no longer register the item, and the item held by the cursor will be erased.
On the other hand, if no items are registered in the slot, the item can be registered as usual.